### PR TITLE
s3 is redirecting all pages without trailing slash to trailing slash.…

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -45,10 +45,10 @@ export default {
   },
   auth: {
     redirect: {
-      login: '/login',
-      logout: '/login',
-      home: '/admin',
-      callback: '/callback'
+      login: '/login/',
+      logout: '/login/',
+      home: '/admin/',
+      callback: '/callback/'
     },
     strategies: {
       noi: {


### PR DESCRIPTION
… This causes a mismatch on the callback uri and nuxt will not redirect the user afterwards.